### PR TITLE
Multimonitor issue fix.

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -1531,6 +1531,7 @@ void on_screen_changed(GtkWidget* widget,
     GdkScreen* screen = gtk_window_get_screen(GTK_WINDOW(greeter.ui.screen_window));
     gdk_screen_get_monitor_geometry(screen, gdk_screen_get_primary_monitor(screen), &geometry);
     gtk_window_set_default_size(GTK_WINDOW(greeter.ui.screen_window), geometry.width, geometry.height);
+    gtk_window_move(GTK_WINDOW(greeter.ui.screen_window), geometry.x, geometry.y);
     if(update_layout)
         update_main_window_layout();
 }


### PR DESCRIPTION
If you have a monitor left of your primary one in X, the greeter it's positioning.

The fix was to also move the window to the x and y of the screen when updating the size.

This is what happens, pardon the crappy camera quality.
![nxgeayz](https://f.cloud.github.com/assets/68832/1412774/9dcf4bca-3deb-11e3-9153-de7bae80c76e.jpg)
